### PR TITLE
Add option to select consul node name as Erlang hostname instead of ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ config :libcluster,
         # node name (before the @ part. If not specified, it will assume
         # the same name as the current running node.
         node_basename: "app_name"
+
+        # Which consul response key should be considered as node
+        # hostname (after the @ part). Accepted values: :ip
+        # or :node_name. Default :ip.
+        host_key: :ip
       ]]]
 ```
 

--- a/lib/strategy/consul/agent.ex
+++ b/lib/strategy/consul/agent.ex
@@ -12,5 +12,5 @@ defmodule Cluster.Strategy.Consul.Agent do
   end
 
   @impl true
-  def parse_response(%{"Address" => ip}), do: [ip]
+  def parse_response(%{"Address" => ip}, _), do: [ip]
 end

--- a/lib/strategy/consul/catalog.ex
+++ b/lib/strategy/consul/catalog.ex
@@ -12,7 +12,13 @@ defmodule Cluster.Strategy.Consul.Catalog do
   end
 
   @impl true
-  def parse_response(response) when is_list(response) do
+  def parse_response(response, :node_name) when is_list(response) do
+    response
+    |> Enum.map(fn %{"Node" => node} -> node end)
+  end
+
+  @impl true
+  def parse_response(response, _) when is_list(response) do
     response
     |> Enum.map(fn %{"ServiceAddress" => ip} -> ip end)
   end

--- a/lib/strategy/consul/endpoint.ex
+++ b/lib/strategy/consul/endpoint.ex
@@ -7,7 +7,7 @@ defmodule Cluster.Strategy.Consul.Endpoint do
 
   @callback build_url(URI.t(), Keyword.t()) :: URI.t()
 
-  @callback parse_response([map]) :: [ip]
+  @callback parse_response([map], Atom.t()) :: [ip]
 
   defmacro __using__(_opts) do
     quote do
@@ -36,7 +36,7 @@ defmodule Cluster.Strategy.Consul.Endpoint do
       {:ok, {{_version, 200, _status}, _headers, body}} ->
         body
         |> Jason.decode!()
-        |> module.parse_response()
+        |> module.parse_response(Keyword.get(config, :host_key, :ip))
         |> Enum.map(&Consul.node_name(&1, config))
 
       {:ok, {{_version, code, status}, _headers, body}} ->

--- a/lib/strategy/consul/health.ex
+++ b/lib/strategy/consul/health.ex
@@ -26,7 +26,14 @@ defmodule Cluster.Strategy.Consul.Health do
   end
 
   @impl true
-  def parse_response(response) when is_list(response) do
+  def parse_response(response, :node_name) when is_list(response) do
+    Enum.map(response, fn
+      %{"Node" => %{"Node" => node}} -> node
+    end)
+  end
+
+  @impl true
+  def parse_response(response, _) when is_list(response) do
     # Fallback to node address when service address is not defined. This mirrors consul's
     # dns behaviour.
     Enum.map(response, fn


### PR DESCRIPTION
This PR adds option to select node name from consul response instead of ip address. It can ce useful for applications which build its erlang node names using application@host pattern instead of application@ip.