### PR TITLE
converted headers to charlists

### DIFF
--- a/lib/strategy/consul.ex
+++ b/lib/strategy/consul.ex
@@ -214,7 +214,7 @@ defmodule Cluster.Strategy.Consul do
         []
 
       access_token ->
-        [{"authorization", "Bearer #{access_token}"}]
+        [{to_charlist("authorization"), to_charlist("Bearer #{access_token}")}]
     end
   end
 


### PR DESCRIPTION
Consul is complaining with request to Consul failed!: {:headers_error, :not_strings}, upon inspecting endpoint.ex the :httpc.request/4 call the Request has url as charlists but the headers not which produces that error, with the headers as charlists as well the problem seems to be fixed