### PR TITLE
Support filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ config :libcluster,
         service: [name: "service_name"],
 
         # Apply filtering
-        filter: ~s("canary" version in Service.Tags),
+        filter: ~s("canary" in Service.Tags),
 
         # NOTE:
         # Alternatively one could specify id for the service using

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ config :libcluster,
         # The default service for children endpoints specifications.
         service: [name: "service_name"],
 
+        # Apply filtering
+        filter: ~s("canary" version in Service.Tags),
+
         # NOTE:
         # Alternatively one could specify id for the service using
         # service: [id: "service_id"]

--- a/lib/strategy/consul.ex
+++ b/lib/strategy/consul.ex
@@ -210,18 +210,9 @@ defmodule Cluster.Strategy.Consul do
       |> Keyword.get(:base_url, @default_base_url)
       |> URI.parse()
 
-    case Keyword.get(config, :dc) do
-      nil ->
-        base_url
-
-      dc ->
-        query =
-          (base_url.query || "")
-          |> URI.decode_query(%{"dc" => dc})
-          |> URI.encode_query()
-
-        %{base_url | query: query}
-    end
+    base_url
+    |> maybe_add_query(:dc, config)
+    |> maybe_add_query(:filter, config)
   end
 
   def headers(config) do
@@ -236,5 +227,20 @@ defmodule Cluster.Strategy.Consul do
 
   def node_name(host_or_ip, config) do
     :"#{Keyword.fetch!(config, :node_basename)}@#{host_or_ip}"
+  end
+
+  defp maybe_add_query(base_url, key, config) do
+    case Keyword.get(config, key) do
+      nil ->
+        base_url
+
+      value ->
+        query =
+          (base_url.query || "")
+          |> URI.decode_query(%{key => value})
+          |> URI.encode_query()
+
+        %{base_url | query: query}
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClusterConsul.MixProject do
   def project do
     [
       app: :libcluster_consul,
-      version: "1.1.1",
+      version: "1.1.2",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClusterConsul.MixProject do
   def project do
     [
       app: :libcluster_consul,
-      version: "1.1.2",
+      version: "1.2.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Adds a configuration option to define a [filter](https://developer.hashicorp.com/consul/api-docs/features/filtering) on the Consul query.