### PR TITLE
Add an option to disable ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ config :libcluster,
 
         # Block when starting the cluster supervisor until after the initial
         # attempt to join the cluster, or join the cluster asynchronously.
-        async_initial_connection?: true
+        async_initial_connection?: true,
+
+        # Disable ssl verification if set to true when making the
+        # http request to consul, defaults to false.
+        disable_verify_ssl?: false,
       ]]]
 ```
 

--- a/lib/strategy/consul.ex
+++ b/lib/strategy/consul.ex
@@ -83,7 +83,11 @@ defmodule Cluster.Strategy.Consul do
 
               # Block when starting the cluster supervisor until after the initial
               # attempt to join the cluster, or join the cluster asynchronously.
-              async_initial_connection?: true
+              async_initial_connection?: true,
+
+              # Disable ssl verification if set to true when making the
+              # http request to consul, defaults to false.
+              disable_verify_ssl?: false
             ]]]
 
 

--- a/lib/strategy/consul/endpoint.ex
+++ b/lib/strategy/consul/endpoint.ex
@@ -32,7 +32,21 @@ defmodule Cluster.Strategy.Consul.Endpoint do
       config
       |> Consul.headers()
 
-    case :httpc.request(:get, {to_charlist(url), headers}, [], []) do
+    disable_verify_ssl? = Keyword.get(config, :disable_verify_ssl?, false)
+
+    opts =
+      if disable_verify_ssl? do
+        [{:ssl, [{:verify, :verify_none}]}]
+      else
+        []
+      end
+
+    case :httpc.request(
+           :get,
+           {to_charlist(url), headers},
+           opts,
+           []
+         ) do
       {:ok, {{_version, 200, _status}, _headers, body}} ->
         body
         |> Jason.decode!()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClusterConsul.MixProject do
   def project do
     [
       app: :libcluster_consul,
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Adds an option to disable ssl verification when making the request to consul.

With last OTP versions and the use of httpc the verification of SSL is automatic, some people might want to have it disabled (especially when using 480)